### PR TITLE
Use string ids instead of int64

### DIFF
--- a/inputs.go
+++ b/inputs.go
@@ -5,10 +5,10 @@ import (
 )
 
 // Get Input Details
-func (z *Zencoder) GetInputDetails(id int32) (*InputMediaFile, error) {
+func (z *Zencoder) GetInputDetails(id string) (*InputMediaFile, error) {
 	var details InputMediaFile
 
-	if err := z.getBody(fmt.Sprintf("inputs/%d.json", id), &details); err != nil {
+	if err := z.getBody(fmt.Sprintf("inputs/%s.json", id), &details); err != nil {
 		return nil, err
 	}
 
@@ -16,10 +16,10 @@ func (z *Zencoder) GetInputDetails(id int32) (*InputMediaFile, error) {
 }
 
 // Input Progress
-func (z *Zencoder) GetInputProgress(id int32) (*FileProgress, error) {
+func (z *Zencoder) GetInputProgress(id string) (*FileProgress, error) {
 	var details FileProgress
 
-	if err := z.getBody(fmt.Sprintf("inputs/%d/progress.json", id), &details); err != nil {
+	if err := z.getBody(fmt.Sprintf("inputs/%s/progress.json", id), &details); err != nil {
 		return nil, err
 	}
 

--- a/inputs_test.go
+++ b/inputs_test.go
@@ -50,7 +50,7 @@ func TestGetInputDetails(t *testing.T) {
 	zc := NewZencoder("abc")
 	zc.BaseUrl = srv.URL
 
-	details, err := zc.GetInputDetails(123)
+	details, err := zc.GetInputDetails("123")
 	if err != nil {
 		t.Fatal("Expected no error", err)
 	}
@@ -86,10 +86,10 @@ func TestGetInputDetails(t *testing.T) {
 	if details.Height != 352 {
 		t.Fatal("Expected 352, got", details.Height)
 	}
-	if details.Id != 6816 {
+	if details.Id != "6816" {
 		t.Fatal("Expected 6816, got", details.Id)
 	}
-	if details.JobId != 6816 {
+	if details.JobId != "6816" {
 		t.Fatal("Expected 6816, got", details.JobId)
 	}
 	if details.Privacy != false {
@@ -119,7 +119,7 @@ func TestGetInputDetails(t *testing.T) {
 
 	expectedStatus = http.StatusInternalServerError
 
-	details, err = zc.GetInputDetails(123)
+	details, err = zc.GetInputDetails("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -131,7 +131,7 @@ func TestGetInputDetails(t *testing.T) {
 	expectedStatus = http.StatusOK
 	returnBody = false
 
-	details, err = zc.GetInputDetails(123)
+	details, err = zc.GetInputDetails("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -143,7 +143,7 @@ func TestGetInputDetails(t *testing.T) {
 	srv.Close()
 	returnBody = true
 
-	details, err = zc.GetInputDetails(123)
+	details, err = zc.GetInputDetails("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -181,7 +181,7 @@ func TestGetInputProgress(t *testing.T) {
 	zc := NewZencoder("abc")
 	zc.BaseUrl = srv.URL
 
-	progress, err := zc.GetInputProgress(123)
+	progress, err := zc.GetInputProgress("123")
 	if err != nil {
 		t.Fatal("Expected no error", err)
 	}
@@ -208,7 +208,7 @@ func TestGetInputProgress(t *testing.T) {
 
 	expectedStatus = http.StatusInternalServerError
 
-	progress, err = zc.GetInputProgress(123)
+	progress, err = zc.GetInputProgress("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -220,7 +220,7 @@ func TestGetInputProgress(t *testing.T) {
 	expectedStatus = http.StatusOK
 	returnBody = false
 
-	progress, err = zc.GetInputProgress(123)
+	progress, err = zc.GetInputProgress("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -232,7 +232,7 @@ func TestGetInputProgress(t *testing.T) {
 	srv.Close()
 	returnBody = true
 
-	progress, err = zc.GetInputProgress(123)
+	progress, err = zc.GetInputProgress("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}

--- a/jobs.go
+++ b/jobs.go
@@ -1,15 +1,16 @@
 package zencoder
 
 import (
+	"encoding/json"
 	"fmt"
 )
 
 type FileProgress struct {
-	Id                   int64   `json:"id,omitempty"`
-	State                string  `json:"state,omitempty"`
-	CurrentEvent         string  `json:"current_event,omitempty"`
-	CurrentEventProgress float64 `json:"current_event_progress,omitempty"`
-	OverallProgress      float64 `json:"progress,omitempty"`
+	Id                   json.Number `json:"id,omitempty"`
+	State                string      `json:"state,omitempty"`
+	CurrentEvent         string      `json:"current_event,omitempty"`
+	CurrentEventProgress float64     `json:"current_event_progress,omitempty"`
+	OverallProgress      float64     `json:"progress,omitempty"`
 }
 
 type JobProgress struct {
@@ -21,67 +22,67 @@ type JobProgress struct {
 
 // Response from CreateJob
 type CreateJobResponse struct {
-	Id      int64 `json:"id,omitempty"`
-	Test    bool  `json:"test,omitempty"`
+	Id      json.Number `json:"id,omitempty"`
+	Test    bool        `json:"test,omitempty"`
 	Outputs []struct {
-		Id    int64   `json:"id,omitempty"`
-		Label *string `json:"label,omitempty"`
-		Url   string  `json:"url,omitempty"`
+		Id    json.Number `json:"id,omitempty"`
+		Label *string     `json:"label,omitempty"`
+		Url   string      `json:"url,omitempty"`
 	} `json:"outputs,omitempty"`
 }
 
 // A MediaFile
 type MediaFile struct {
-	Id                 int64   `json:"id,omitempty"`
-	Url                string  `json:"url,omitempty"`
-	Format             string  `json:"format,omitempty"`
-	State              string  `json:"state,omitempty"`
-	Test               bool    `json:"test,omitempty"`
-	Privacy            bool    `json:"privacy"`
-	Width              int32   `json:"width,omitempty"`
-	Height             int32   `json:"height,omitempty"`
-	FrameRate          float64 `json:"frame_rate,omitempty"`
-	DurationInMs       int32   `json:"duration_in_ms,omitempty"`
-	Channels           string  `json:"channels,omitempty"`
-	AudioCodec         string  `json:"audio_codec,omitempty"`
-	AudioBitrateInKbps int32   `json:"audio_bitrate_in_kbps,omitempty"`
-	AudioSampleRate    int32   `json:"audio_sample_rate,omitempty"`
-	VideoCodec         string  `json:"video_codec,omitempty"`
-	VideoBitrateInKbps int32   `json:"video_bitrate_in_kbps,omitempty"`
-	TotalBitrateInKbps int32   `json:"total_bitrate_in_kbps,omitempty"`
-	MD5Checksum        string  `json:"md5_checksum,omitempty"`
-	ErrorMessage       *string `json:"error_message,omitempty"`
-	ErrorClass         *string `json:"error_class,omitempty"`
-	Label              *string `json:"label,omitempty"`
-	CreatedAt          string  `json:"created_at,omitempty"`
-	FinishedAt         string  `json:"finished_at,omitempty"`
-	UpdatedAt          string  `json:"updated_at,omitempty"`
-	FileSizeInBytes    int64   `json:"file_size_bytes,omitempty"`
+	Id                 json.Number `json:"id,omitempty"`
+	Url                string      `json:"url,omitempty"`
+	Format             string      `json:"format,omitempty"`
+	State              string      `json:"state,omitempty"`
+	Test               bool        `json:"test,omitempty"`
+	Privacy            bool        `json:"privacy"`
+	Width              int32       `json:"width,omitempty"`
+	Height             int32       `json:"height,omitempty"`
+	FrameRate          float64     `json:"frame_rate,omitempty"`
+	DurationInMs       int32       `json:"duration_in_ms,omitempty"`
+	Channels           string      `json:"channels,omitempty"`
+	AudioCodec         string      `json:"audio_codec,omitempty"`
+	AudioBitrateInKbps int32       `json:"audio_bitrate_in_kbps,omitempty"`
+	AudioSampleRate    int32       `json:"audio_sample_rate,omitempty"`
+	VideoCodec         string      `json:"video_codec,omitempty"`
+	VideoBitrateInKbps int32       `json:"video_bitrate_in_kbps,omitempty"`
+	TotalBitrateInKbps int32       `json:"total_bitrate_in_kbps,omitempty"`
+	MD5Checksum        string      `json:"md5_checksum,omitempty"`
+	ErrorMessage       *string     `json:"error_message,omitempty"`
+	ErrorClass         *string     `json:"error_class,omitempty"`
+	Label              *string     `json:"label,omitempty"`
+	CreatedAt          string      `json:"created_at,omitempty"`
+	FinishedAt         string      `json:"finished_at,omitempty"`
+	UpdatedAt          string      `json:"updated_at,omitempty"`
+	FileSizeInBytes    int64       `json:"file_size_bytes,omitempty"`
 }
 
 type InputMediaFile struct {
 	MediaFile
-	FileSizeInBytes int64 `json:"file_size_in_bytes,omitempty"`
-	JobId           int64 `json:"job_id,omitempty"`
+	FileSizeInBytes int64       `json:"file_size_in_bytes,omitempty"`
+	JobId           json.Number `json:"job_id,omitempty"`
 }
 
 type OutputMediaFile struct {
 	MediaFile
-	FileSizeInBytes int64 `json:"file_size_in_bytes,omitempty"`
-	JobId           int64 `json:"job_id,omitempty"`
+	FileSizeInBytes int64       `json:"file_size_in_bytes,omitempty"`
+	JobId           json.Number `json:"job_id,omitempty"`
 }
 
 // A Thumbnail
 type Thumbnail struct {
-	Id        int64  `json:"id,omitempty"`
-	Url       string `json:"url,omitempty"`
-	CreatedAt string `json:"created_at,omitempty"`
-	UpdatedAt string `json:"updated_at,omitempty"`
+	Id        json.Number `json:"id,omitempty"`
+	Url       string      `json:"url,omitempty"`
+	CreatedAt string      `json:"created_at,omitempty"`
+	UpdatedAt string      `json:"updated_at,omitempty"`
 }
 
 // A Job
 type Job struct {
-	Id               int64        `json:"id,omitempty"`
+	Id               json.Number  `json:"id,omitempty"`
 	PassThrough      *string      `json:"pass_through,omitempty"`
 	State            string       `json:"state,omitempty"`
 	InputMediaFile   *MediaFile   `json:"input_media_file,omitempty"`
@@ -122,10 +123,10 @@ func (z *Zencoder) ListJobs() ([]*JobDetails, error) {
 }
 
 // Get Job Details
-func (z *Zencoder) GetJobDetails(id int64) (*JobDetails, error) {
+func (z *Zencoder) GetJobDetails(id string) (*JobDetails, error) {
 	var result JobDetails
 
-	if err := z.getBody(fmt.Sprintf("jobs/%d.json", id), &result); err != nil {
+	if err := z.getBody(fmt.Sprintf("jobs/%s.json", id), &result); err != nil {
 		return nil, err
 	}
 
@@ -133,10 +134,10 @@ func (z *Zencoder) GetJobDetails(id int64) (*JobDetails, error) {
 }
 
 // Job Progress
-func (z *Zencoder) GetJobProgress(id int64) (*JobProgress, error) {
+func (z *Zencoder) GetJobProgress(id string) (*JobProgress, error) {
 	var result JobProgress
 
-	if err := z.getBody(fmt.Sprintf("jobs/%d/progress.json", id), &result); err != nil {
+	if err := z.getBody(fmt.Sprintf("jobs/%s/progress.json", id), &result); err != nil {
 		return nil, err
 	}
 
@@ -144,16 +145,16 @@ func (z *Zencoder) GetJobProgress(id int64) (*JobProgress, error) {
 }
 
 // Resubmit a Job
-func (z *Zencoder) ResubmitJob(id int64) error {
-	return z.putNoContent(fmt.Sprintf("jobs/%d/resubmit.json", id))
+func (z *Zencoder) ResubmitJob(id string) error {
+	return z.putNoContent(fmt.Sprintf("jobs/%s/resubmit.json", id))
 }
 
 // Cancel a Job
-func (z *Zencoder) CancelJob(id int64) error {
-	return z.putNoContent(fmt.Sprintf("jobs/%d/cancel.json", id))
+func (z *Zencoder) CancelJob(id string) error {
+	return z.putNoContent(fmt.Sprintf("jobs/%s/cancel.json", id))
 }
 
 // Finish a Live Job
-func (z *Zencoder) FinishLiveJob(id int64) error {
-	return z.putNoContent(fmt.Sprintf("jobs/%d/finish", id))
+func (z *Zencoder) FinishLiveJob(id string) error {
+	return z.putNoContent(fmt.Sprintf("jobs/%s/finish", id))
 }

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -40,7 +40,7 @@ func TestCreateJob(t *testing.T) {
 		t.Fatal("Expected a response")
 	}
 
-	if resp.Id != 1234 {
+	if resp.Id != "1234" {
 		t.Fatal("Expected Id=1234", resp.Id)
 	}
 
@@ -48,7 +48,7 @@ func TestCreateJob(t *testing.T) {
 		t.Fatal("Expected one output", len(resp.Outputs))
 	}
 
-	if resp.Outputs[0].Id != 4321 {
+	if resp.Outputs[0].Id != "4321" {
 		t.Fatal("Expected Id=4321", resp.Outputs[0].Id)
 	}
 
@@ -204,7 +204,7 @@ func TestListJobs(t *testing.T) {
 	if jobs[0].Job.PassThrough != nil {
 		t.Fatal("Expected nil, got", jobs[0].Job.PassThrough)
 	}
-	if jobs[0].Job.Id != 1 {
+	if jobs[0].Job.Id != "1" {
 		t.Fatal("Expected 1, got", jobs[0].Job.Id)
 	}
 	if jobs[0].Job.InputMediaFile.Format != "mpeg4" {
@@ -231,7 +231,7 @@ func TestListJobs(t *testing.T) {
 	if jobs[0].Job.InputMediaFile.Url != "s3://bucket/test.mp4" {
 		t.Fatal("Expected s3://bucket/test.mp4, got", jobs[0].Job.InputMediaFile.Url)
 	}
-	if jobs[0].Job.InputMediaFile.Id != 1 {
+	if jobs[0].Job.InputMediaFile.Id != "1" {
 		t.Fatal("Expected 1, got", jobs[0].Job.InputMediaFile.Id)
 	}
 	if jobs[0].Job.InputMediaFile.ErrorMessage != nil {
@@ -303,7 +303,7 @@ func TestListJobs(t *testing.T) {
 	if jobs[0].Job.OutputMediaFiles[0].Url != "http://s3.amazonaws.com/bucket/video.mp4" {
 		t.Fatal("Expected http://s3.amazonaws.com/bucket/video.mp4, got", jobs[0].Job.OutputMediaFiles[0].Url)
 	}
-	if jobs[0].Job.OutputMediaFiles[0].Id != 1 {
+	if jobs[0].Job.OutputMediaFiles[0].Id != "1" {
 		t.Fatal("Expected 1, got", jobs[0].Job.OutputMediaFiles[0].Id)
 	}
 	if jobs[0].Job.OutputMediaFiles[0].ErrorMessage != nil {
@@ -360,7 +360,7 @@ func TestListJobs(t *testing.T) {
 	if jobs[0].Job.Thumbnails[0].Url != "http://s3.amazonaws.com/bucket/video/frame_0000.png" {
 		t.Fatal("Expected http://s3.amazonaws.com/bucket/video/frame_0000.png, got", jobs[0].Job.Thumbnails[0].Url)
 	}
-	if jobs[0].Job.Thumbnails[0].Id != 1 {
+	if jobs[0].Job.Thumbnails[0].Id != "1" {
 		t.Fatal("Expected 1, got", jobs[0].Job.Thumbnails[0].Id)
 	}
 	if jobs[0].Job.State != "finished" {
@@ -491,7 +491,7 @@ func TestGetJobDetails(t *testing.T) {
 	zc := NewZencoder("abc")
 	zc.BaseUrl = srv.URL
 
-	details, err := zc.GetJobDetails(123)
+	details, err := zc.GetJobDetails("123")
 	if err != nil {
 		t.Fatal("Expected no error", err)
 	}
@@ -515,7 +515,7 @@ func TestGetJobDetails(t *testing.T) {
 	if details.Job.PassThrough != nil {
 		t.Fatal("Expected nil, got", details.Job.PassThrough)
 	}
-	if details.Job.Id != 1 {
+	if details.Job.Id != "1" {
 		t.Fatal("Expected 1, got", details.Job.Id)
 	}
 	if details.Job.Test != false {
@@ -549,7 +549,7 @@ func TestGetJobDetails(t *testing.T) {
 	if details.Job.InputMediaFile.Url != "s3://bucket/test.mp4" {
 		t.Fatal("Expected s3://bucket/test.mp4, got", details.Job.InputMediaFile.Url)
 	}
-	if details.Job.InputMediaFile.Id != 1 {
+	if details.Job.InputMediaFile.Id != "1" {
 		t.Fatal("Expected 1, got", details.Job.InputMediaFile.Id)
 	}
 	if details.Job.InputMediaFile.ErrorMessage != nil {
@@ -619,7 +619,7 @@ func TestGetJobDetails(t *testing.T) {
 	if details.Job.OutputMediaFiles[0].Url != "http://s3.amazonaws.com/bucket/video.mp4" {
 		t.Fatal("Expected http://s3.amazonaws.com/bucket/video.mp4, got", details.Job.OutputMediaFiles[0].Url)
 	}
-	if details.Job.OutputMediaFiles[0].Id != 1 {
+	if details.Job.OutputMediaFiles[0].Id != "1" {
 		t.Fatal("Expected 1, got", details.Job.OutputMediaFiles[0].Id)
 	}
 	if details.Job.OutputMediaFiles[0].ErrorMessage != nil {
@@ -676,12 +676,12 @@ func TestGetJobDetails(t *testing.T) {
 	if details.Job.Thumbnails[0].Url != "http://s3.amazonaws.com/bucket/video/frame_0000.png" {
 		t.Fatal("Expected http://s3.amazonaws.com/bucket/video/frame_0000.png, got", details.Job.Thumbnails[0].Url)
 	}
-	if details.Job.Thumbnails[0].Id != 1 {
+	if details.Job.Thumbnails[0].Id != "1" {
 		t.Fatal("Expected 1, got", details.Job.Thumbnails[0].Id)
 	}
 
 	expectedStatus = http.StatusNotFound
-	details, err = zc.GetJobDetails(123)
+	details, err = zc.GetJobDetails("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -692,7 +692,7 @@ func TestGetJobDetails(t *testing.T) {
 
 	expectedStatus = http.StatusOK
 	returnBody = false
-	details, err = zc.GetJobDetails(123)
+	details, err = zc.GetJobDetails("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -703,7 +703,7 @@ func TestGetJobDetails(t *testing.T) {
 
 	returnBody = false
 	srv.Close()
-	details, err = zc.GetJobDetails(123)
+	details, err = zc.GetJobDetails("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -759,7 +759,7 @@ func TestGetJobProgress(t *testing.T) {
 	zc := NewZencoder("abc")
 	zc.BaseUrl = srv.URL
 
-	progress, err := zc.GetJobProgress(123)
+	progress, err := zc.GetJobProgress("123")
 	if err != nil {
 		t.Fatal("Expected no error", err)
 	}
@@ -774,7 +774,7 @@ func TestGetJobProgress(t *testing.T) {
 	if progress.JobProgress != 32.34567345 {
 		t.Fatal("Expected 32.34567345, got", progress.JobProgress)
 	}
-	if progress.InputProgress.Id != 1234 {
+	if progress.InputProgress.Id != "1234" {
 		t.Fatal("Expected 1234, got", progress.InputProgress.Id)
 	}
 	if progress.InputProgress.State != "finished" {
@@ -785,7 +785,7 @@ func TestGetJobProgress(t *testing.T) {
 		t.Fatal("Expected 2 outputs, got", len(progress.OutputProgress))
 	}
 
-	if progress.OutputProgress[0].Id != 4567 {
+	if progress.OutputProgress[0].Id != "4567" {
 		t.Fatal("Expected 4567, got", progress.OutputProgress[0].Id)
 	}
 	if progress.OutputProgress[0].State != "processing" {
@@ -802,7 +802,7 @@ func TestGetJobProgress(t *testing.T) {
 	}
 
 	expectedStatus = http.StatusNotFound
-	progress, err = zc.GetJobProgress(123)
+	progress, err = zc.GetJobProgress("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -813,7 +813,7 @@ func TestGetJobProgress(t *testing.T) {
 
 	expectedStatus = http.StatusOK
 	returnBody = false
-	progress, err = zc.GetJobProgress(123)
+	progress, err = zc.GetJobProgress("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -824,7 +824,7 @@ func TestGetJobProgress(t *testing.T) {
 
 	returnBody = true
 	srv.Close()
-	progress, err = zc.GetJobProgress(123)
+	progress, err = zc.GetJobProgress("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -847,14 +847,14 @@ func TestResubmitJob(t *testing.T) {
 	zc := NewZencoder("abc")
 	zc.BaseUrl = srv.URL
 
-	err := zc.ResubmitJob(123)
+	err := zc.ResubmitJob("123")
 	if err != nil {
 		t.Fatal("Expected no error", err)
 	}
 
 	expectedStatus = http.StatusConflict
 
-	err = zc.ResubmitJob(123)
+	err = zc.ResubmitJob("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -862,7 +862,7 @@ func TestResubmitJob(t *testing.T) {
 	expectedStatus = http.StatusOK
 	srv.Close()
 
-	err = zc.ResubmitJob(123)
+	err = zc.ResubmitJob("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -881,14 +881,14 @@ func TestCancelJob(t *testing.T) {
 	zc := NewZencoder("abc")
 	zc.BaseUrl = srv.URL
 
-	err := zc.CancelJob(123)
+	err := zc.CancelJob("123")
 	if err != nil {
 		t.Fatal("Expected no error", err)
 	}
 
 	expectedStatus = http.StatusConflict
 
-	err = zc.CancelJob(123)
+	err = zc.CancelJob("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -896,7 +896,7 @@ func TestCancelJob(t *testing.T) {
 	expectedStatus = http.StatusOK
 	srv.Close()
 
-	err = zc.CancelJob(123)
+	err = zc.CancelJob("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -915,14 +915,14 @@ func TestFinishLiveJob(t *testing.T) {
 	zc := NewZencoder("abc")
 	zc.BaseUrl = srv.URL
 
-	err := zc.FinishLiveJob(123)
+	err := zc.FinishLiveJob("123")
 	if err != nil {
 		t.Fatal("Expected no error", err)
 	}
 
 	expectedStatus = http.StatusConflict
 
-	err = zc.FinishLiveJob(123)
+	err = zc.FinishLiveJob("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}

--- a/outputs.go
+++ b/outputs.go
@@ -5,10 +5,10 @@ import (
 )
 
 // Get Output Details
-func (z *Zencoder) GetOutputDetails(id int64) (*OutputMediaFile, error) {
+func (z *Zencoder) GetOutputDetails(id string) (*OutputMediaFile, error) {
 	var details OutputMediaFile
 
-	if err := z.getBody(fmt.Sprintf("outputs/%d.json", id), &details); err != nil {
+	if err := z.getBody(fmt.Sprintf("outputs/%s.json", id), &details); err != nil {
 		return nil, err
 	}
 
@@ -16,10 +16,10 @@ func (z *Zencoder) GetOutputDetails(id int64) (*OutputMediaFile, error) {
 }
 
 // Output Progress
-func (z *Zencoder) GetOutputProgress(id int64) (*FileProgress, error) {
+func (z *Zencoder) GetOutputProgress(id string) (*FileProgress, error) {
 	var details FileProgress
 
-	if err := z.getBody(fmt.Sprintf("outputs/%d/progress.json", id), &details); err != nil {
+	if err := z.getBody(fmt.Sprintf("outputs/%s/progress.json", id), &details); err != nil {
 		return nil, err
 	}
 

--- a/outputs_test.go
+++ b/outputs_test.go
@@ -49,7 +49,7 @@ func TestGetOutputDetails(t *testing.T) {
 	zc := NewZencoder("abc")
 	zc.BaseUrl = srv.URL
 
-	details, err := zc.GetOutputDetails(123)
+	details, err := zc.GetOutputDetails("123")
 	if err != nil {
 		t.Fatal("Expected no error", err)
 	}
@@ -85,7 +85,7 @@ func TestGetOutputDetails(t *testing.T) {
 	if details.Height != 352 {
 		t.Fatal("Expected 352, got", details.Height)
 	}
-	if details.Id != 13339 {
+	if details.Id != "13339" {
 		t.Fatal("Expected 13339, got", details.Id)
 	}
 	if details.Label != nil {
@@ -115,7 +115,7 @@ func TestGetOutputDetails(t *testing.T) {
 
 	expectedStatus = http.StatusInternalServerError
 
-	details, err = zc.GetOutputDetails(123)
+	details, err = zc.GetOutputDetails("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -127,7 +127,7 @@ func TestGetOutputDetails(t *testing.T) {
 	expectedStatus = http.StatusOK
 	returnBody = false
 
-	details, err = zc.GetOutputDetails(123)
+	details, err = zc.GetOutputDetails("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -139,7 +139,7 @@ func TestGetOutputDetails(t *testing.T) {
 	srv.Close()
 	returnBody = true
 
-	details, err = zc.GetOutputDetails(123)
+	details, err = zc.GetOutputDetails("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -177,7 +177,7 @@ func TestGetOutputProgress(t *testing.T) {
 	zc := NewZencoder("abc")
 	zc.BaseUrl = srv.URL
 
-	progress, err := zc.GetOutputProgress(123)
+	progress, err := zc.GetOutputProgress("123")
 	if err != nil {
 		t.Fatal("Expected no error", err)
 	}
@@ -204,7 +204,7 @@ func TestGetOutputProgress(t *testing.T) {
 
 	expectedStatus = http.StatusInternalServerError
 
-	progress, err = zc.GetOutputProgress(123)
+	progress, err = zc.GetOutputProgress("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -216,7 +216,7 @@ func TestGetOutputProgress(t *testing.T) {
 	expectedStatus = http.StatusOK
 	returnBody = false
 
-	progress, err = zc.GetOutputProgress(123)
+	progress, err = zc.GetOutputProgress("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -228,7 +228,7 @@ func TestGetOutputProgress(t *testing.T) {
 	srv.Close()
 	returnBody = true
 
-	progress, err = zc.GetOutputProgress(123)
+	progress, err = zc.GetOutputProgress("123")
 	if err == nil {
 		t.Fatal("Expected error")
 	}


### PR DESCRIPTION
For some reason, zencoder API encodes ids without quotes, so it seems
it treats them as numbers internally. However, all official clients use
strings for id representation which, for various reasons, makes more
sense than using ints.

This is an attempt to tackle #1 . I don't like the idea of using json.Number, as I think zencoder should either fix their API into encoding IDs as strings or their clients into using ints for IDs.
It's not even clear if the IDs are unsigned and how many bits they should be. string IDs should be a safe option for everyone.