### PR TITLE
Added source field on StreamSettings struct

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -46,6 +46,7 @@ type NotificationSettings struct {
 }
 
 type StreamSettings struct {
+	Source     string `json:"source,omitempty"`     // Specifies the label of a given source
 	Path       string `json:"path,omitempty"`       // Specifies the path to a stream manifest file
 	Bandwidth  int32  `json:"bandwidth,omitempty"`  // Specifies the bandwidth of a playlist stream
 	Resolution string `json:"resolution,omitempty"` // Specifies the resolution of a playlist stream


### PR DESCRIPTION
Based on https://app.zencoder.com/docs/guides/encoding-settings/http-live-streaming:

> You can create adaptive-bitrate playlists yourself, or have Zencoder do it as part of a job. To have us create the playlist, just add another output to your job with a type of "playlist" and specify one or more streams with a path (that is relative to the playlist file's location) and the source of the stream, which is the label of the corresponding output. Bandwidth, resolution, and codec can also be specified, but by default these are inferred from the source. The stream information will be formatted into a playlist and uploaded just like any other output.
